### PR TITLE
Add missing py.typed file - closes #663

### DIFF
--- a/newsfragments/663.bugfix.rst
+++ b/newsfragments/663.bugfix.rst
@@ -1,0 +1,1 @@
+Add missing py.typed file.


### PR DESCRIPTION
Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number
