### PR TITLE
feat: Remove/Keep only specified DBs in mongodb_factory

### DIFF
--- a/newsfragments/812.feature.rst
+++ b/newsfragments/812.feature.rst
@@ -1,2 +1,3 @@
-Improve mongodb_factory to delete the only provided databases.
+Improve mongodb_factory to keep or delete provided databases.
 It's useful to run xdist tests in parallel, and avoid deleting databases created by other test workers.
+Now you can keep preseed databases which won't be deleted after each test.

--- a/newsfragments/812.feature.rst
+++ b/newsfragments/812.feature.rst
@@ -1,0 +1,2 @@
+Improve mongodb_factory to delete the only provided databases.
+It's useful to run xdist tests in parallel, and avoid deleting databases created by other test workers.

--- a/pytest_mongo/config.py
+++ b/pytest_mongo/config.py
@@ -16,6 +16,7 @@ class MongoConfig:
     port_search_count: int
     params: str
     tz_aware: bool
+    databases: list[str] | None
 
 
 def get_config(request: FixtureRequest) -> MongoConfig:
@@ -34,5 +35,6 @@ def get_config(request: FixtureRequest) -> MongoConfig:
         port_search_count=int(get_mongo_option("port_search_count")),
         params=get_mongo_option("params"),
         tz_aware=get_mongo_option("tz_aware"),
+        databases=get_mongo_option("databases"),
     )
     return cfg

--- a/pytest_mongo/config.py
+++ b/pytest_mongo/config.py
@@ -16,7 +16,8 @@ class MongoConfig:
     port_search_count: int
     params: str
     tz_aware: bool
-    databases: list[str] | None
+    remove_dbs: list[str] | None
+    keep_dbs: list[str] | None
 
 
 def get_config(request: FixtureRequest) -> MongoConfig:
@@ -35,6 +36,7 @@ def get_config(request: FixtureRequest) -> MongoConfig:
         port_search_count=int(get_mongo_option("port_search_count")),
         params=get_mongo_option("params"),
         tz_aware=get_mongo_option("tz_aware"),
-        databases=get_mongo_option("databases"),
+        remove_dbs=get_mongo_option("remove_dbs"),
+        keep_dbs=get_mongo_option("keep_dbs"),
     )
     return cfg

--- a/pytest_mongo/factories/client.py
+++ b/pytest_mongo/factories/client.py
@@ -12,16 +12,24 @@ from pytest_mongo.config import get_config
 def mongodb(
     process_fixture_name: str,
     tz_aware: bool | None = None,
-    databases: list[str] | None = None,
+    remove_dbs: list[str] | None = None,
+    keep_dbs: list[str] | None = None,
 ) -> Callable[[FixtureRequest], Iterator[MongoClient]]:
     """Mongo database factory.
 
     :param str process_fixture_name: name of the process fixture
     :param bool tz_aware: whether the client to be timezone aware or not
-    :param list databases: list of database names to be cleaned
+    :param list remove_dbs: list of database names to be cleaned
+    :param list keep_dbs: list of database names to be kept
     :rtype: func
     :returns: function which makes a connection to mongo
     """
+
+    if remove_dbs is not None and keep_dbs is not None and set(remove_dbs).intersection(set(keep_dbs)):
+        raise ValueError(
+            "remove_dbs and keep_dbs cannot have overlapping database names"
+        )
+
 
     @pytest.fixture
     def mongodb_factory(request: FixtureRequest) -> Iterator[MongoClient]:
@@ -39,11 +47,17 @@ def mongodb(
         elif config.tz_aware is not None and isinstance(config.tz_aware, bool):
             mongo_tz_aware = config.tz_aware
 
-        mongo_databases = None
-        if databases is not None:
-            mongo_databases = databases
-        elif config.databases is not None and isinstance(config.databases, list):
-            mongo_databases = config.databases
+        mongo_remove_dbs = None
+        if remove_dbs is not None:
+            mongo_remove_dbs = remove_dbs
+        elif config.remove_dbs is not None and isinstance(config.remove_dbs, list):
+            mongo_remove_dbs = config.remove_dbs
+
+        mongo_keep_dbs = None
+        if keep_dbs is not None:
+            mongo_keep_dbs = keep_dbs
+        elif config.keep_dbs is not None and isinstance(config.keep_dbs, list):
+            mongo_keep_dbs = config.keep_dbs
 
         mongo_host = mongodb_process.host
         mongo_port = mongodb_process.port
@@ -53,7 +67,10 @@ def mongodb(
         yield mongo_conn
 
         for db_name in mongo_conn.list_database_names():
-            if mongo_databases and db_name not in mongo_databases:
+            if mongo_keep_dbs and db_name in mongo_keep_dbs:
+                continue
+
+            if mongo_remove_dbs and db_name not in mongo_remove_dbs:
                 continue
 
             database = mongo_conn[db_name]

--- a/pytest_mongo/factories/client.py
+++ b/pytest_mongo/factories/client.py
@@ -24,12 +24,12 @@ def mongodb(
     :rtype: func
     :returns: function which makes a connection to mongo
     """
-
-    if remove_dbs is not None and keep_dbs is not None and set(remove_dbs).intersection(set(keep_dbs)):
-        raise ValueError(
-            "remove_dbs and keep_dbs cannot have overlapping database names"
-        )
-
+    if (
+        remove_dbs is not None
+        and keep_dbs is not None
+        and set(remove_dbs).intersection(set(keep_dbs))
+    ):
+        raise ValueError("remove_dbs and keep_dbs cannot have overlapping database names")
 
     @pytest.fixture
     def mongodb_factory(request: FixtureRequest) -> Iterator[MongoClient]:

--- a/pytest_mongo/factories/client.py
+++ b/pytest_mongo/factories/client.py
@@ -18,7 +18,7 @@ def mongodb(
 
     :param str process_fixture_name: name of the process fixture
     :param bool tz_aware: whether the client to be timezone aware or not
-    :param list databases: list of database names to be cleaned, if None all databases will be cleaned
+    :param list databases: list of database names to be cleaned
     :rtype: func
     :returns: function which makes a connection to mongo
     """

--- a/pytest_mongo/factories/client.py
+++ b/pytest_mongo/factories/client.py
@@ -18,6 +18,7 @@ def mongodb(
 
     :param str process_fixture_name: name of the process fixture
     :param bool tz_aware: whether the client to be timezone aware or not
+    :param list databases: list of database names to be cleaned, if None all databases will be cleaned
     :rtype: func
     :returns: function which makes a connection to mongo
     """
@@ -38,6 +39,12 @@ def mongodb(
         elif config.tz_aware is not None and isinstance(config.tz_aware, bool):
             mongo_tz_aware = config.tz_aware
 
+        mongo_databases = None
+        if databases is not None:
+            mongo_databases = databases
+        elif config.databases is not None and isinstance(config.databases, list):
+            mongo_databases = config.databases
+
         mongo_host = mongodb_process.host
         mongo_port = mongodb_process.port
 
@@ -46,7 +53,7 @@ def mongodb(
         yield mongo_conn
 
         for db_name in mongo_conn.list_database_names():
-            if databases and db_name not in databases:
+            if mongo_databases and db_name not in mongo_databases:
                 continue
 
             database = mongo_conn[db_name]

--- a/pytest_mongo/factories/client.py
+++ b/pytest_mongo/factories/client.py
@@ -10,7 +10,9 @@ from pytest_mongo.config import get_config
 
 
 def mongodb(
-    process_fixture_name: str, tz_aware: bool | None = None
+    process_fixture_name: str,
+    tz_aware: bool | None = None,
+    databases: list[str] | None = None,
 ) -> Callable[[FixtureRequest], Iterator[MongoClient]]:
     """Mongo database factory.
 
@@ -44,6 +46,9 @@ def mongodb(
         yield mongo_conn
 
         for db_name in mongo_conn.list_database_names():
+            if databases and db_name not in databases:
+                continue
+
             database = mongo_conn[db_name]
             for collection_name in database.list_collection_names():
                 collection = database[collection_name]

--- a/pytest_mongo/plugin.py
+++ b/pytest_mongo/plugin.py
@@ -31,8 +31,12 @@ _help_tz_aware = (
     "Have mongo client timezone aware (ini: mongo_tz_aware; "
     "use --mongo-tz-aware/--no-mongo-tz-aware to override)"
 )
-_help_databases = (
+_help_remove_dbs = (
     "List of MongoDB databases to clean in the fixture. Otherwise, all databases "
+    "are cleaned excluding system.*. collections"
+)
+_help_keep_dbs = (
+    "List of MongoDB databases to keep in the fixture. Otherwise, all databases "
     "are cleaned excluding system.*. collections"
 )
 
@@ -62,8 +66,14 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
     parser.addini(
-        name="mongo_databases",
-        help=_help_databases,
+        name="mongo_remove_dbs",
+        help=_help_remove_dbs,
+        default=[],
+    )
+
+    parser.addini(
+        name="mongo_keep_dbs",
+        help=_help_keep_dbs,
         default=[],
     )
 
@@ -106,9 +116,17 @@ def pytest_addoption(parser: Parser) -> None:
         help=_help_tz_aware,
     )
     parser.addoption(
-        "--mongo-databases",
-        help=_help_databases,
-        dest="mongo_databases",
+        "--mongo-remove-dbs",
+        help=_help_remove_dbs,
+        dest="mongo_remove_dbs",
+        type=str,
+        nargs="*",
+        action="extend",
+    )
+    parser.addoption(
+        "--mongo-keep-dbs",
+        help=_help_keep_dbs,
+        dest="mongo_keep_dbs",
         type=str,
         nargs="*",
         action="extend",

--- a/pytest_mongo/plugin.py
+++ b/pytest_mongo/plugin.py
@@ -33,7 +33,7 @@ _help_tz_aware = (
 )
 _help_databases = (
     "List of MongoDB databases to clean in the fixture. Otherwise, all databases "
-    "are cleaned exclude system.*."
+    "are cleaned excluding system.*. collections"
 )
 
 

--- a/pytest_mongo/plugin.py
+++ b/pytest_mongo/plugin.py
@@ -31,6 +31,10 @@ _help_tz_aware = (
     "Have mongo client timezone aware (ini: mongo_tz_aware; "
     "use --mongo-tz-aware/--no-mongo-tz-aware to override)"
 )
+_help_databases = (
+    "List of MongoDB databases to clean in the fixture. Otherwise, all databases "
+    "are cleaned exclude system.*."
+)
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -55,6 +59,12 @@ def pytest_addoption(parser: Parser) -> None:
         help=_help_tz_aware,
         type="bool",
         default=False,
+    )
+
+    parser.addini(
+        name="mongo_databases",
+        help=_help_databases,
+        default=[],
     )
 
     parser.addoption(
@@ -94,6 +104,14 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_false",
         dest="mongo_tz_aware",
         help=_help_tz_aware,
+    )
+    parser.addoption(
+        "--mongo-databases",
+        help=_help_databases,
+        dest="mongo_databases",
+        type=str,
+        nargs="*",
+        action="extend",
     )
 
 

--- a/pytest_mongo/plugin.py
+++ b/pytest_mongo/plugin.py
@@ -67,12 +67,14 @@ def pytest_addoption(parser: Parser) -> None:
 
     parser.addini(
         name="mongo_remove_dbs",
+        type="args",
         help=_help_remove_dbs,
         default=[],
     )
 
     parser.addini(
         name="mongo_keep_dbs",
+        type="args",
         help=_help_keep_dbs,
         default=[],
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,5 +15,6 @@ mongo_proc_rand = process.mongo_proc(port=None, params=mongo_params)
 mongodb_rand = client.mongodb("mongo_proc_rand")
 
 mongo_proc4 = process.mongo_proc(port=27072, params=mongo_params)
-mongodb4 = client.mongodb("mongo_proc4", databases=["test_db"])
+mongodb4 = client.mongodb("mongo_proc4", remove_dbs=["test_db"])
+mongodb5 = client.mongodb("mongo_proc4", keep_dbs=["test_db2"])
 # pylint:enable=invalid-name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,4 +13,7 @@ mongodb3 = client.mongodb("mongo_proc3")
 
 mongo_proc_rand = process.mongo_proc(port=None, params=mongo_params)
 mongodb_rand = client.mongodb("mongo_proc_rand")
+
+mongo_proc4 = process.mongo_proc(port=27072, params=mongo_params)
+mongodb4 = client.mongodb("mongo_proc4", databases=["test_db"])
 # pylint:enable=invalid-name

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -56,22 +56,3 @@ def test_random_port(mongodb_rand: MongoClient) -> None:
     server_info = mongodb_rand.server_info()
     assert "ok" in server_info
     assert server_info["ok"] == 1.0
-
-
-class TestCleanSpecifiedDatabases:
-    """Test if only specified databases are cleaned."""
-
-    def test_clean_specified_databases(self, mongodb4: MongoClient) -> None:
-        """Test if only specified databases are cleaned."""
-        test_db = mongodb4["test_db"]
-        test_db.test.insert_one({"test": "test"})
-        test_db2 = mongodb4["test_db2"]
-        test_db2.test.insert_one({"test": "test"})
-
-        assert "test_db" in mongodb4.list_database_names()
-        assert "test_db2" in mongodb4.list_database_names()
-
-    def test_clean_specified_databases_again(self, mongodb4: MongoClient) -> None:
-        """Test if only specified databases are cleaned."""
-        assert "test_db" not in mongodb4.list_database_names()
-        assert "test_db2" in mongodb4.list_database_names()

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -57,6 +57,7 @@ def test_random_port(mongodb_rand: MongoClient) -> None:
     assert "ok" in server_info
     assert server_info["ok"] == 1.0
 
+
 class TestCleanSpecifiedDatabases:
     """Test if only specified databases are cleaned."""
 

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -56,3 +56,21 @@ def test_random_port(mongodb_rand: MongoClient) -> None:
     server_info = mongodb_rand.server_info()
     assert "ok" in server_info
     assert server_info["ok"] == 1.0
+
+class TestCleanSpecifiedDatabases:
+    """Test if only specified databases are cleaned."""
+
+    def test_clean_specified_databases(self, mongodb4: MongoClient) -> None:
+        """Test if only specified databases are cleaned."""
+        test_db = mongodb4["test_db"]
+        test_db.test.insert_one({"test": "test"})
+        test_db2 = mongodb4["test_db2"]
+        test_db2.test.insert_one({"test": "test"})
+
+        assert "test_db" in mongodb4.list_database_names()
+        assert "test_db2" in mongodb4.list_database_names()
+
+    def test_clean_specified_databases_again(self, mongodb4: MongoClient) -> None:
+        """Test if only specified databases are cleaned."""
+        assert "test_db" not in mongodb4.list_database_names()
+        assert "test_db2" in mongodb4.list_database_names()

--- a/tests/test_mongo_cleanup.py
+++ b/tests/test_mongo_cleanup.py
@@ -1,3 +1,5 @@
+"""Test MongoDB cleanup functionality."""
+
 from pymongo import MongoClient
 
 

--- a/tests/test_mongo_cleanup.py
+++ b/tests/test_mongo_cleanup.py
@@ -1,5 +1,6 @@
 from pymongo import MongoClient
 
+
 def test_clean_specified_databases(mongodb4: MongoClient) -> None:
     """Test if only specified databases are cleaned."""
     test_db = mongodb4["test_db"]
@@ -10,10 +11,12 @@ def test_clean_specified_databases(mongodb4: MongoClient) -> None:
     assert "test_db" in mongodb4.list_database_names()
     assert "test_db2" in mongodb4.list_database_names()
 
+
 def test_clean_specified_databases_again(mongodb5: MongoClient) -> None:
     """Test if only specified databases are cleaned."""
     assert "test_db" not in mongodb5.list_database_names()
     assert "test_db2" in mongodb5.list_database_names()
+
 
 def test_keep_specified_databases(mongodb5: MongoClient) -> None:
     assert "test_db" not in mongodb5.list_database_names()

--- a/tests/test_mongo_cleanup.py
+++ b/tests/test_mongo_cleanup.py
@@ -1,0 +1,20 @@
+from pymongo import MongoClient
+
+def test_clean_specified_databases(mongodb4: MongoClient) -> None:
+    """Test if only specified databases are cleaned."""
+    test_db = mongodb4["test_db"]
+    test_db.test.insert_one({"test": "test"})
+    test_db2 = mongodb4["test_db2"]
+    test_db2.test.insert_one({"test": "test"})
+
+    assert "test_db" in mongodb4.list_database_names()
+    assert "test_db2" in mongodb4.list_database_names()
+
+def test_clean_specified_databases_again(mongodb5: MongoClient) -> None:
+    """Test if only specified databases are cleaned."""
+    assert "test_db" not in mongodb5.list_database_names()
+    assert "test_db2" in mongodb5.list_database_names()
+
+def test_keep_specified_databases(mongodb5: MongoClient) -> None:
+    assert "test_db" not in mongodb5.list_database_names()
+    assert "test_db2" in mongodb5.list_database_names()

--- a/tests/test_mongo_cleanup.py
+++ b/tests/test_mongo_cleanup.py
@@ -19,5 +19,6 @@ def test_clean_specified_databases_again(mongodb5: MongoClient) -> None:
 
 
 def test_keep_specified_databases(mongodb5: MongoClient) -> None:
+    """Test if only specified databases are kept."""
     assert "test_db" not in mongodb5.list_database_names()
     assert "test_db2" in mongodb5.list_database_names()


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to clean up only selected MongoDB databases, either by removing specified databases or keeping specified ones.
  * Introduced matching command-line and configuration settings for finer control over database cleanup.

* **Bug Fixes**
  * Cleanup now avoids deleting unrelated databases, helping prevent interference with parallel test runs and shared MongoDB instances.

* **Tests**
  * Expanded test coverage to verify the new database filtering behaviour during fixture teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->